### PR TITLE
Fixed bug that causes mrgaze_tune.py to crash.

### DIFF
--- a/mrgaze_tune.py
+++ b/mrgaze_tune.py
@@ -118,8 +118,8 @@ class ExamplePanel(wx.Panel):
         self.logger.AppendText('EvtCheckBox: %d\n' % event.Checked())
 
 
-app = wx.App(False)
-frame = wx.Frame(False)
+app = wx.App(None)
+frame = wx.Frame(None)
 panel = ExamplePanel(frame)
 frame.Show()
 app.MainLoop()


### PR DESCRIPTION
wx.Window (and, by extension it's subclass wx.Frame) constructors take the
window's parent as an argument. When creating a window without a parent,
the argument None shoud be passed. In this case, False was being passed,
which caused a type error.