### PR TITLE
Removed "merge marks" from pupilometry and media.

### DIFF
--- a/mrgaze/media.py
+++ b/mrgaze/media.py
@@ -86,14 +86,8 @@ def Preproc(fr, cfg):
 
     # Preprocessing flags
     perc_range = (perclow, perchigh)
-<<<<<<< HEAD
-<<<<<<< HEAD
     bias_correct = False
-=======
-=======
->>>>>>> master
     bias_correct = True
->>>>>>> master
     
     # Init returned artifact power
     art_power = 0.0    

--- a/mrgaze/pupilometry.py
+++ b/mrgaze/pupilometry.py
@@ -33,10 +33,8 @@ import getpass
 import cv2
 import json
 import numpy as np
-<<<<<<< HEAD
 from skimage import measure, morphology
 from mrgaze import media, utils, fitellipse, improc
-=======
 import scipy.ndimage as spi
 from skimage.measure import label, regionprops
 from mrgaze import media, utils, fitellipse, improc, config, calibrate, report


### PR DESCRIPTION
I removed "<<<<<<HEAD" "======" and other bits of code used created by git during
a merge. These were causing the program to crash when run. No testing on actual
data done, but at least it doesn't immediately cause python to crash with
a syntax error :).